### PR TITLE
Several optimizations (mostly duplicates from Oddysee)

### DIFF
--- a/LegnaXplitter Abe's Exoddus 1.1.asl
+++ b/LegnaXplitter Abe's Exoddus 1.1.asl
@@ -1,6 +1,6 @@
 //  An autosplitter for Abe's Exoddus for PC: English / English GoG, Spanish, French / French Steam, German and Italian. 
 //  Language should be detected automatically by looking for the localised "are you sure you want to quit" string (thanks to paulsapp). 
-//  Created by LegnaX. 26 May 2022.
+//  Created by LegnaX. Optimized by UltraStars3000. 12 Jan 2025.
 
  // Added this so the ASL Var Viewer has at least one opcode loaded by default (even if it's unused). 
 state("Exoddus", "default") {byte use_Variables_option_instead  : 0x1C3030;}
@@ -12,7 +12,7 @@ startup
 {
 	print("+startup");
 
-	settings.Add("Version", true, "Official Version 2.1 (May 26th 2022) - LegnaX#7777 - CHANGELOG");
+	settings.Add("Version", true, "Official Version 3.0 (Jan 12th 2025) - LegnaX#7777 - CHANGELOG");
 	settings.SetToolTip("Version", 
 	@"########################################## CHANGELOG ########################################## 
 -Added Individual level support!
@@ -25,7 +25,8 @@ startup
 -Fixed a visual glitch with the IGT and added new condition to split on Executive Office - Entry and Executive Office - Aslik (for 100%, Max Cas and 50/50 categories).
 -Completely revamped the init system (thanks to Paul) and added support to the Relive project (also made by Paul). paul#2754 - paulsapps.com
 -Fixed a problem with the ASL Var Viewer. It should let you choose the variables correctly now (found by TopTheGamer and MarkTheW0lf).
--[May 26th 2022] Fixed compatibility with relive. It should work now (thanks to mouzedrift)."
+-[May 26th 2022] Fixed compatibility with relive. It should work now (thanks to mouzedrift).
+-Optimized in-game time handling, making the internal LiveSplit timer consistent with the variable one."
 );
 	
 	settings.Add("version2", true, "Use Game Time as timer (will be Loadless).");
@@ -445,6 +446,19 @@ start
 		vars.AccumulatedPenaltyTime = 0;	
 		startingWithMines = false;	
 		vars.Terminal2Split = false;
+
+		// Moved from the split method
+		vars.SplitFeeco2 = false;
+		vars.preSplitNecrum = false;
+		vars.preSplitMudomo = false;
+		vars.preSplitMudanchee = false;
+		vars.splitsFeeCoAgain = false;		
+		vars.PrePhlegSplit = false; // This variable checks if Phleg made it to the Glukkon intercom at least once. Prevents a wrong split if the player dies at Phleg on the last tier of Slogs.
+	
+		bool[] splitsTemp = new bool[95];	
+		vars.splits = splitsTemp;	
+		vars.countToMud = 0;
+
 		return true;
 	}
 }
@@ -550,969 +564,955 @@ split
 	int o_FMV_ID = -1;
 	int c_FMV_ID = -1;
 	int abeY = -1;
-	vars.LOG_CurrentRTA = "[" + System.Convert.ToString(timer.CurrentTime.RealTime).Replace("0000", "") + "]";
-	if (System.Convert.ToString(timer.CurrentTime.RealTime).Contains("00:00:00")) { // Used for resetting the main variables of the program if the timer resets. 		
-		vars.SplitFeeco2 = false;
-		vars.preSplitNecrum = false;
-		vars.preSplitMudomo = false;
-		vars.preSplitMudanchee = false;
-		vars.splitsFeeCoAgain = false;		
-		vars.PrePhlegSplit = false; // This variable checks if Phleg made it to the Glukkon intercom at least once. Prevents a wrong split if the player dies at Phleg on the last tier of Slogs.
+	vars.LOG_CurrentRTA = "[" + System.Convert.ToString(timer.CurrentTime.RealTime).Replace("0000", "") + "]";	
+	if (vars.version == ""){
+		// Game version not yet detected
+	} else if (settings["SPLITSinfo"] || vars.ILid >= 0){
+		o_LEVEL_ID = vars.watchers["LEVEL_ID"].Old;
+		c_LEVEL_ID = vars.watchers["LEVEL_ID"].Current;
+		o_PATH_ID = vars.watchers["PATH_ID"].Old;
+		c_PATH_ID = vars.watchers["PATH_ID"].Current;
+		o_CAM_ID = vars.watchers["CAM_ID"].Old;
+		c_CAM_ID = vars.watchers["CAM_ID"].Current;
+		o_FMV_ID = vars.watchers["FMV_ID"].Old;
+		c_FMV_ID = vars.watchers["FMV_ID"].Current;
+		abeY = vars.watchers["abeY"].Current;
 	
-		bool[] splitsTemp = new bool[95];	
-		vars.splits = splitsTemp;	
-		vars.countToMud = 0;
-	} else { 
-	
-		if (vars.version == ""){
-			// Game version not yet detected
-		} else if (settings["SPLITSinfo"] || vars.ILid >= 0){
-			o_LEVEL_ID = vars.watchers["LEVEL_ID"].Old;
-			c_LEVEL_ID = vars.watchers["LEVEL_ID"].Current;
-			o_PATH_ID = vars.watchers["PATH_ID"].Old;
-			c_PATH_ID = vars.watchers["PATH_ID"].Current;
-			o_CAM_ID = vars.watchers["CAM_ID"].Old;
-			c_CAM_ID = vars.watchers["CAM_ID"].Current;
-			o_FMV_ID = vars.watchers["FMV_ID"].Old;
-			c_FMV_ID = vars.watchers["FMV_ID"].Current;
-			abeY = vars.watchers["abeY"].Current;
-		
-							
-			// Mines (LEVEL_ID 1)
-				if (settings["minesSplit"] || vars.ILid == 0) {		
-					if (c_LEVEL_ID == 1) { // If we are in Mines...		
-						if (settings["minesExtended"] || vars.ILid == 0){ // 14 - 21
-						// Tunnel 1 SPLIT
-							if (c_FMV_ID == 71 && vars.splits[14] != true) {
-								vars.splits[14] = true;
-								vars.LOG_LastSplit = "Tunnel 1. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Tunnel 2 SPLIT
-							if (o_PATH_ID == 2 && c_PATH_ID == 3 && vars.splits[15] != true) {
-								vars.splits[15] = true;
-								vars.LOG_LastSplit = "Tunnel 2. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Slog SPLIT
-							if (o_PATH_ID == 3 && c_PATH_ID == 4 && vars.splits[16] != true) {
-								vars.splits[16] = true;
-								vars.LOG_LastSplit = "Slogs. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Tunnel 3 SPLIT
-							if (c_FMV_ID == 32 && vars.splits[17] != true) {
-								vars.splits[17] = true;
-								vars.LOG_LastSplit = "Tunnel 3. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Tunnel 4 SPLIT
-							if (c_FMV_ID == 17 && vars.splits[18] != true) {
-								vars.splits[18] = true;
-								vars.LOG_LastSplit = "Tunnel 4. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Tunnel 5 SPLIT
-							if (c_FMV_ID == 5 && vars.splits[19] != true) {
-								vars.splits[19] = true;
-								vars.LOG_LastSplit = "Tunnel 5. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Tunnel 6 SPLIT
-							if (c_FMV_ID == 30 && vars.splits[20] != true) {
-								vars.splits[20] = true;
-								vars.LOG_LastSplit = "Tunnel 6. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Tunnel 7 SPLIT
-							if (c_FMV_ID == 28 && vars.splits[21] != true) {
-								vars.splits[21] = true;
-								vars.LOG_LastSplit = "Tunnel 7. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-						}
 						
-					// MINES SPLIT
-						if (c_FMV_ID == 232 && vars.splits[0] != true) {
-							vars.splits[0] = true;
-							vars.LOG_LastSplit = "Mines, last split. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-					}
-				}
-			//////////////////////////////
-
-			// Mudomo (LEVEL_ID 3, Vaults is LEVEL_ID 11)
-				if (settings["mudomoSplit"] || vars.ILid == 2){
-					if (c_LEVEL_ID == 3 && (settings["mudomoExtended"] || vars.ILid == 2)){ // 30 - 39
-					
-					// Mudomo Entry 1
-						if (c_FMV_ID == 29 && vars.splits[30] != true) {
-								vars.splits[30] = true;
-								vars.LOG_LastSplit = "Mudomo Entry 1. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Mudomo Entry 2
-						if (c_FMV_ID == 33 && vars.splits[31] != true) {
-								vars.splits[31] = true;
-								vars.LOG_LastSplit = "Mudomo Entry 2. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Mudomo Entry 3
-						if (c_PATH_ID == 8 && vars.splits[32] != true) {
-								vars.splits[32] = true;
-								vars.LOG_LastSplit = "Mudomo Entry 3. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Mudomo Trial 1
-						if (c_FMV_ID == 13 && vars.splits[33] != true) {
-								vars.splits[33] = true;
-								vars.LOG_LastSplit = "Mudomo Trial 1. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Mudomo Trial 2
-						if (c_FMV_ID == 17 && vars.splits[34] != true) {
-								vars.splits[34] = true;
-								vars.LOG_LastSplit = "Mudomo Trial 2. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Mudomo Trial 3
-						if (c_FMV_ID == 15 && vars.splits[35] != true) {
-								vars.splits[35] = true;
-								vars.LOG_LastSplit = "Mudomo Trial 3. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Mudomo Trial 4
-						if (c_FMV_ID == 9 && vars.splits[36] != true) {
-								vars.splits[36] = true;
-								vars.LOG_LastSplit = "Mudomo Trial 4. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Mudomo Trial 5
-						if (c_FMV_ID == 6 && vars.splits[37] != true) {
-								vars.splits[37] = true;
-								vars.LOG_LastSplit = "Mudomo Trial 5. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Mudomo Trial 6
-						if (c_FMV_ID == 31 && vars.splits[38] != true) {
-								vars.splits[38] = true;
-								vars.LOG_LastSplit = "Mudomo Trial 6. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					}
-					
-				// Mudomo Vaults
-					if ((settings["mudomoExtended"] || vars.ILid == 2) && o_LEVEL_ID == 11 && c_LEVEL_ID == 2 && vars.splits[39] != true) {
-						vars.splits[39] = true;
-						vars.LOG_LastSplit = "Mudomo Vaults. " + vars.LOG_CurrentRTA;
+		// Mines (LEVEL_ID 1)
+		if (settings["minesSplit"] || vars.ILid == 0) {		
+			if (c_LEVEL_ID == 1) { // If we are in Mines...		
+				if (settings["minesExtended"] || vars.ILid == 0){ // 14 - 21
+				// Tunnel 1 SPLIT
+					if (c_FMV_ID == 71 && vars.splits[14] != true) {
+						vars.splits[14] = true;
+						vars.LOG_LastSplit = "Tunnel 1. " + vars.LOG_CurrentRTA;
 						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
 						return true;
 					}
 					
-				// PRE-Mudomo split
-					if (c_LEVEL_ID == 2 && c_PATH_ID == 5 && c_CAM_ID == 1 && c_FMV_ID != 8){ 
-						vars.preSplitMudomo = true;
+				// Tunnel 2 SPLIT
+					if (o_PATH_ID == 2 && c_PATH_ID == 3 && vars.splits[15] != true) {
+						vars.splits[15] = true;
+						vars.LOG_LastSplit = "Tunnel 2. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
 					}
+					
+				// Slog SPLIT
+					if (o_PATH_ID == 3 && c_PATH_ID == 4 && vars.splits[16] != true) {
+						vars.splits[16] = true;
+						vars.LOG_LastSplit = "Slogs. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Tunnel 3 SPLIT
+					if (c_FMV_ID == 32 && vars.splits[17] != true) {
+						vars.splits[17] = true;
+						vars.LOG_LastSplit = "Tunnel 3. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Tunnel 4 SPLIT
+					if (c_FMV_ID == 17 && vars.splits[18] != true) {
+						vars.splits[18] = true;
+						vars.LOG_LastSplit = "Tunnel 4. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Tunnel 5 SPLIT
+					if (c_FMV_ID == 5 && vars.splits[19] != true) {
+						vars.splits[19] = true;
+						vars.LOG_LastSplit = "Tunnel 5. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Tunnel 6 SPLIT
+					if (c_FMV_ID == 30 && vars.splits[20] != true) {
+						vars.splits[20] = true;
+						vars.LOG_LastSplit = "Tunnel 6. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Tunnel 7 SPLIT
+					if (c_FMV_ID == 28 && vars.splits[21] != true) {
+						vars.splits[21] = true;
+						vars.LOG_LastSplit = "Tunnel 7. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+				}
 				
-				// Mudomo split
-					if ((vars.countToMud >= 1000 || vars.ILid == 2) && ((c_LEVEL_ID == 4 && c_PATH_ID == 6 && c_CAM_ID == 23 && c_FMV_ID == 34 && vars.preSplitMudomo) || (o_PATH_ID == 3 && c_PATH_ID == 1 && c_LEVEL_ID == 5)) && vars.splits[2] != true) { 
-						vars.splits[2] = true;
-						vars.LOG_LastSplit = "Mudomo. " + vars.LOG_CurrentRTA;
-						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-						return true;
-					}
-				}
-			//////////////////////////////
-
-			// Mudanchee (LEVEL_ID 4)
-				if (settings["mudancheeSplit"] || vars.ILid == 3){
-					if (settings["mudancheeExtended"] || vars.ILid == 3){ // 40 - 50
-						if (c_LEVEL_ID == 4){
-						// Mudanchee Entry 1
-							if (c_FMV_ID == 25 && vars.splits[40] != true) {
-								vars.splits[40] = true;
-								vars.LOG_LastSplit = "Mudanchee Entry 1. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Mudanchee Entry 2
-							if (c_FMV_ID == 30 && vars.splits[41] != true) {
-								vars.splits[41] = true;
-								vars.LOG_LastSplit = "Mudanchee Entry 2. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Mudanchee Entry 3
-							if (c_FMV_ID == 28 && vars.splits[42] != true) {
-								vars.splits[42] = true;
-								vars.LOG_LastSplit = "Mudanchee Entry 3. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Mudanchee Entry 4
-							if (c_PATH_ID == 7 && o_CAM_ID == 2 && c_CAM_ID == 4 && vars.splits[43] != true) {
-								vars.splits[43] = true;
-								vars.LOG_LastSplit = "Mudanchee Entry 4. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Mudanchee Trial 1
-							if (c_FMV_ID == 2 && vars.splits[44] != true) {
-								vars.splits[44] = true;
-								vars.LOG_LastSplit = "Mudanchee Trial 1. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Mudanchee Trial 2
-							if (c_FMV_ID == 6 && vars.splits[45] != true) {
-								vars.splits[45] = true;
-								vars.LOG_LastSplit = "Mudanchee Trial 2. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Mudanchee Trial 3
-							if (c_FMV_ID == 23 && vars.splits[46] != true) {
-								vars.splits[46] = true;
-								vars.LOG_LastSplit = "Mudanchee Trial 3. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Mudanchee Trial 4
-							if (c_FMV_ID == 14 && vars.splits[47] != true) {
-								vars.splits[47] = true;
-								vars.LOG_LastSplit = "Mudanchee Trial 4. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Mudanchee Trial 5
-							if (c_FMV_ID == 3 && vars.splits[48] != true) {
-								vars.splits[48] = true;
-								vars.LOG_LastSplit = "Mudanchee Trial 5. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Mudanchee Trial 6
-							if (c_FMV_ID == 11 && vars.splits[49] != true) {
-								vars.splits[49] = true;
-								vars.LOG_LastSplit = "Mudanchee Trial 6. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-						}
-						
-					// Mudanchee Vaults
-						if (o_LEVEL_ID == 7 && c_LEVEL_ID == 2 && vars.splits[50] != true) { 
-							vars.splits[50] = true;
-							vars.LOG_LastSplit = "Mudanchee Vaults. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-					}
-
-					if (c_LEVEL_ID == 2 && c_PATH_ID == 5 && c_CAM_ID == 9 && c_FMV_ID != 8){ // Pre-Mudanchee split
-						vars.preSplitMudanchee = true;
-					}
-					
-					if ((vars.countToMud >= 1000 || vars.ILid == 3) && ((c_LEVEL_ID == 3 && c_PATH_ID == 1 && c_CAM_ID == 1 && c_FMV_ID == 25 && vars.preSplitMudanchee) || (o_PATH_ID == 3 && c_PATH_ID == 1 && c_LEVEL_ID == 5)) && vars.splits[3] != true) { // Mudanchee Split: we are in Mudomo or Wheel to FeeCo. 
-						vars.splits[3] = true;
-						vars.LOG_LastSplit = "Mudanchee. " + vars.LOG_CurrentRTA;
-						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-						return true;
-					}
-				}
-			//////////////////////////////
-				
-			// Necrum (LEVEL_ID 2)
-				if (settings["necrumSplit"] || vars.ILid == 1) {
-					if (c_LEVEL_ID == 2){
-						if (settings["necrumExtended"] || vars.ILid == 1) { // 22 - 29
-						// Necrum Entry SPLIT
-							if (c_FMV_ID == 10 && vars.splits[22] != true) {
-								vars.splits[22] = true;
-								vars.LOG_LastSplit = "Necrum Entry. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Hands SPLIT
-							if (c_FMV_ID == 9 && vars.splits[23] != true) {
-								vars.splits[23] = true;
-								vars.LOG_LastSplit = "Handstones. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Fleeches Entry SPLIT
-							if (c_FMV_ID == 6 && vars.splits[24] != true) {
-								vars.splits[24] = true;
-								vars.LOG_LastSplit = "Fleeches Entry. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Fleeches 1 SPLIT
-							if (c_FMV_ID == 18 && vars.splits[25] != true) {
-								vars.splits[25] = true;
-								vars.LOG_LastSplit = "Fleeches 1. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Fleeches 2 SPLIT
-							if (c_FMV_ID == 19 && vars.splits[26] != true) {
-								vars.splits[26] = true;
-								vars.LOG_LastSplit = "Fleeches 2. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Fleeches 3 SPLIT
-							if (c_FMV_ID == 20 && vars.splits[27] != true) {
-								vars.splits[27] = true;
-								vars.LOG_LastSplit = "Fleeches 3. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Fleeches 4 SPLIT
-							if (c_FMV_ID == 21 && vars.splits[28] != true) {
-								vars.splits[28] = true;
-								vars.LOG_LastSplit = "Fleeches 4. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Fleeches 5 SPLIT
-							if (c_FMV_ID == 15 && vars.splits[29] != true) {
-								vars.splits[29] = true;
-								vars.LOG_LastSplit = "Fleeches 5. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-						}
-						
-					// Necrum pre-SPLIT
-						if (c_PATH_ID == 5 && (c_CAM_ID == 9 || c_CAM_ID == 1) && vars.FMVNecrum == 8){ // Prepare for last split
-							vars.preSplitNecrum = true;
-							vars.FMVNecrum = 0;
-						}			
-					} 
-					
-					if (c_LEVEL_ID == 2 && c_FMV_ID == 8){
-						vars.FMVNecrum = c_FMV_ID;
-					}
-					
-					// Necrum SPLITS
-					if (vars.ILid == -1 && vars.preSplitNecrum && (c_FMV_ID == 25 || c_FMV_ID == 34) && (c_LEVEL_ID >= 2 && c_LEVEL_ID <= 4) && vars.splits[1] != true) { // Cinematics: 25 is mudomo (24 end). 34 is Mudanchee (25 end). 4 is FeeCo.
-						vars.splits[1] = true;
-						vars.preSplitNecrum = false;
-						vars.countToMud = 1;
-						vars.LOG_LastSplit = "Necrum to Mudomo / Mudanchee. " + vars.LOG_CurrentRTA;
-						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-						return true;
-					}
-					
-					if (vars.ILid == 1 && o_LEVEL_ID == 2 && c_LEVEL_ID == 3 && c_FMV_ID == 25){ // Necrum to Mudomo, we prepare to the next save file
-						vars.ILWaitTimer = true;						
-						vars.splits[55] = true; // Recycled for Necrum to Mudanchee split
-						return true;
-					}
-					
-					if (vars.ILid == 1 && o_CAM_ID == 5 && c_CAM_ID == 6 && vars.splits[55] == true){ // Save file 2.
-						vars.ILWaitTimer = false;						
-						vars.splits[55] = false;
-						return true;
-					}
-					
-					if (vars.ILid == 1 && o_LEVEL_ID == 2 && c_LEVEL_ID == 4 && c_FMV_ID == 34){ // Necrum to Mudanchee, we prepare to the next save file
-						vars.ILWaitTimer = true;						
-						vars.splits[56] = true; // Recycled for Necrum to FeeCo split
-						return true;
-					}					
-					
-					if (vars.ILid == 1 && o_LEVEL_ID == 7 && c_LEVEL_ID == 2 && vars.splits[56] == true){ // Save file 3.
-						vars.ILWaitTimer = false;						
-						vars.splits[56] = false; // Recycled for Necrum to Mudanchee split
-						return true;
-					}
-					
-					if (c_LEVEL_ID == 5 && o_LEVEL_ID == 2 && ((vars.splits[2] != true && vars.splits[3] != true) || (vars.ILid == 1))){ // From Necrum to FeeCo directly (Any%)
-						vars.splits[1] = true;
-						vars.splits[2] = true; // We will not use it anymore.
-						vars.splits[3] = true; // We will not use it anymore.
-						vars.preSplitNecrum = false;
-						vars.LOG_LastSplit = "Necrum to FeeCo. " + vars.LOG_CurrentRTA;
-						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-						return true;
-					}
-				}
-			//////////////////////////////
-
-			// FeeCo & FeeCo 2 (LEVEL_ID 5)
-				if (settings["feecoSplit"] || vars.ILid == 4) { 					
-					if ((settings["feecoExtended"] || vars.ILid == 4) && c_LEVEL_ID == 2 && o_PATH_ID == 3 && o_CAM_ID == 2 && c_PATH_ID == 3 && c_CAM_ID == 9 && vars.splits[1] == true && vars.splits[2] == true && vars.splits[3] == true) { // SPECIAL: FeeCo entry through Necrum using Farewell FeeCo skip
-						vars.splits[51] = true;
-						vars.LOG_LastSplit = "Special split: Necrum to Terminal 1 (Any% | Farewell FeeCo skip). " + vars.LOG_CurrentRTA;
-						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-						return true;
-					}
-					
-					if ((settings["feecoExtended"] || vars.ILid == 4) && c_LEVEL_ID == 5) { // 51 - 55		
-					// FeeCo Entry
-						if (c_PATH_ID == 1 && c_CAM_ID == 3 && vars.splits[51] != true) {
-							vars.splits[51] = true;
-							vars.LOG_LastSplit = "FeeCo Entry. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Terminal 1
-						if (c_PATH_ID == 7 && c_CAM_ID == 1 && vars.splits[52] != true) {
-							vars.splits[52] = true;
-							vars.LOG_LastSplit = "Terminal 1. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Terminal 2
-						if (o_PATH_ID == 7 && c_PATH_ID == 2 && c_CAM_ID == 8 && (vars.splits[53] != true || vars.splits[0] == true || vars.splits[1] == true) && vars.Terminal2Split == false) { // 0 is for 2nd save. 1 is for 3rd save file.
-							vars.Terminal2Split = true;
-							vars.splits[53] = true;
-							if (vars.splits[1] == true){ // Loading the second save file						
-								vars.LOG_LastSplit = "Terminal 2 (go to Executive Office!) " + vars.LOG_CurrentRTA;	
-							} else if (vars.splits[0] == true){ // Loading the third save file					
-								vars.LOG_LastSplit = "Terminal 2 (go to Bonewerkz!) " + vars.LOG_CurrentRTA;			
-							} else { // First time we come here
-								vars.LOG_LastSplit = "Terminal 2 (go to Barracks!) " + vars.LOG_CurrentRTA;								
-							}
-							if (vars.splits[1] == true){								
-								vars.splits[0] = false;
-								vars.splits[1] = false;
-							}
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							vars.ILWaitTimer = false;
-							return true;
-						}
-						
-					// Terminal principal to Slig Barracks
-					 // if (o_PATH_ID == 9 && c_PATH_ID == 5 && vars.splits[54] != true) { // If I enter on Terminal 3
-						if (o_PATH_ID == 9 && c_PATH_ID == 3 && vars.splits[54] != true) { // If I enter on Terminal 3
-							vars.splits[54] = true;
-							vars.Terminal2Split = false;
-							vars.LOG_LastSplit = "Main Terminal to Terminal 3. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Terminal principal to Bonewerkz
-						if (o_PATH_ID == 9 && c_PATH_ID == 4 && vars.splits[54] != true) { // If I enter on Terminal 4
-							vars.splits[54] = true;
-							vars.Terminal2Split = false;
-							vars.LOG_LastSplit = "Main Terminal to Terminal 4. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Terminal principal to Soulstorm Brewery
-						if (o_PATH_ID == 2 && c_PATH_ID == 5 && vars.splits[54] != true) { // If I enter on Terminal 5
-							vars.splits[54] = true;
-							vars.Terminal2Split = false;
-							vars.LOG_LastSplit = "Main Terminal to Terminal 5. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-							
-					// Terminal 3
-						if (c_PATH_ID == 5 && o_CAM_ID == 3 && c_CAM_ID == 14 && vars.splits[55] != true) {
-							vars.splits[55] = true;
-							vars.Terminal2Split = false;
-							vars.LOG_LastSplit = "Terminal 3. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-							
-					// Terminal 4
-						if (vars.ILid == -1 && c_PATH_ID == 4 && o_CAM_ID == 13 && c_CAM_ID == 14 && vars.splits[55] != true) {
-							vars.splits[55] = true;
-							vars.Terminal2Split = false;
-							vars.LOG_LastSplit = "Terminal 4. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-							
-					// Terminal 5
-						if (c_PATH_ID == 5 && o_CAM_ID == 7 && c_CAM_ID == 14 && vars.splits[55] != true) {
-							vars.splits[55] = true;
-							vars.Terminal2Split = false;
-							vars.LOG_LastSplit = "Terminal 5. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-					}		
-				}
-				// Enter on any of the train doors
-				if (vars.ILid == 4 && o_LEVEL_ID == 5 && (c_LEVEL_ID == 6 || c_LEVEL_ID == 8 || c_LEVEL_ID == 9) && (vars.splits[0] != true || vars.splits[1] != true)){ 				
-					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-					vars.ILWaitTimer = true;	
-					vars.Terminal2Split = false;					
-					if (vars.splits[0] == false){								
-						vars.splits[0] = true;						
-						vars.LOG_LastSplit = "FeeCo 1. (LOAD SAVE FILE 2)" + vars.LOG_CurrentRTA;
-					} else {						
-						vars.splits[1] = true;		
-						vars.LOG_LastSplit = "FeeCo 2. (LOAD SAVE FILE 3)" + vars.LOG_CurrentRTA;	
-					}
-					return true;
-				}
-					
-				if (vars.ILid == -1 && (settings["feecoSplit"] || vars.SplitFeeco2 || vars.ILid == 4) && o_LEVEL_ID == 5 && (c_LEVEL_ID == 6 || c_LEVEL_ID == 8 || c_LEVEL_ID == 9) && vars.splits[4] != true) { // FeeCo Split. 6 is Bonewerkz.  5 is Barracks. 15 is Brewery
-					vars.splits[4] = true;
-					vars.splitsFeeCoAgain = vars.splits[4];
-					vars.splits[8] = true; // We avoid double split if we go from FeeCo to Soulstorm directly.
-					if (vars.splits[5]) { // Slig Barracks ya fue completado.
-						vars.LOG_LastSplit = "FeeCo 2 to Bonewerkz. " + vars.LOG_CurrentRTA;
-					} else if (vars.splits[6]){ // Bonewerkz ya fue completado.
-						vars.LOG_LastSplit = "FeeCo 2 to Slig Barracks. " + vars.LOG_CurrentRTA;		
-					} else { // Nada fue completado.
-						vars.LOG_LastSplit = "FeeCo 1. " + vars.LOG_CurrentRTA;
-					}
+			// MINES SPLIT
+				if (c_FMV_ID == 232 && vars.splits[0] != true) {
+					vars.splits[0] = true;
+					vars.LOG_LastSplit = "Mines, last split. " + vars.LOG_CurrentRTA;
 					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
 					return true;
 				}
-			//////////////////////////////
-					
-			// Slig Barracks (LEVEL_ID 6)
-				if (settings["barracksSplit"] || vars.ILid == 6) {
-					if ((settings["barracksExtended"] || vars.ILid == 6) && c_LEVEL_ID == 6) { // 56 - 62			
-					// Block 0
-						if (o_PATH_ID == 13 && c_PATH_ID == 2 && vars.splits[56] != true) {
-							vars.splits[56] = true;
-							vars.LOG_LastSplit = "Block 0. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Block 1
-						if (o_PATH_ID == 10 && c_PATH_ID == 2 && vars.splits[57] != true) {
-							vars.splits[57] = true;
-							vars.LOG_LastSplit = "Block 1. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Block 2
-						if (o_PATH_ID == 5 && c_PATH_ID == 2 && vars.splits[58] != true) {
-							vars.splits[58] = true;
-							vars.LOG_LastSplit = "Block 2. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Block 3
-						if (o_PATH_ID == 7 && c_PATH_ID == 2 && vars.splits[59] != true) {
-							vars.splits[59] = true;
-							vars.LOG_LastSplit = "Block 3. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Block 4
-						if (o_PATH_ID == 14 && c_PATH_ID == 2 && vars.splits[60] != true) {
-							vars.splits[60] = true;
-							vars.LOG_LastSplit = "Block 4. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}	
-					
-					}
-				// Dripik (fixed 08 June 2020)
-					if ((settings["barracksExtended"] || vars.ILid == 6) && c_LEVEL_ID == 13 && o_PATH_ID == 11 && c_PATH_ID == 16 && vars.splits[61] != true) {
-						vars.splits[61] = true;
-						vars.LOG_LastSplit = "Dripik. " + vars.LOG_CurrentRTA;
-						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-						return true;
-					}	
-					
-					
-					
-				// Slig Barracks Split
-					if (o_LEVEL_ID == 13 && c_LEVEL_ID == 5 && vars.splits[5] != true) { 
-						vars.splits[5] = true;
-						vars.splits[8] = false; // If we are not going directly from FeeCo to Soulstorm, we can split on FeeCo 2.
-						if (settings["feeco2Split"] && vars.SplitFeeco2 == false){
-							vars.splits[4] = false; // So we split again when entering on Bonewerkz.
-							vars.splitsFeeCoAgain = vars.splits[4];
-							vars.SplitFeeco2 = true;
-						}
-						vars.LOG_LastSplit = "Slig Barracks. " + vars.LOG_CurrentRTA;
-						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-						return true;
-					}
-				}
-			//////////////////////////////
-					
-			// Bonewerkz (LEVEL_ID 8 and 14)
-				if (settings["bonewerkzSplit"] || vars.ILid == 5) {
-					if (settings["bonewerkzExtended"] || vars.ILid == 5) { // 63 - 72
-						if (c_LEVEL_ID == 8){			
-						// Bonewerkz Entry
-							if (o_PATH_ID == 1 && c_PATH_ID == 7 && vars.splits[63] != true) {
-								vars.splits[63] = true;
-								vars.LOG_LastSplit = "Bonewerkz Entry. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Annex 1
-							if (o_PATH_ID == 7 && c_PATH_ID == 1 && vars.splits[64] != true) {
-								vars.splits[64] = true;
-								vars.LOG_LastSplit = "Annex 1. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Annex 2
-							if (o_PATH_ID == 1 && c_PATH_ID == 2 && vars.splits[65] != true) {
-								vars.splits[65] = true;
-								vars.LOG_LastSplit = "Annex 2. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Annex 3
-							if (c_PATH_ID == 2 && c_CAM_ID == 4 && vars.splits[66] != true) {
-								vars.splits[66] = true;
-								vars.LOG_LastSplit = "Annex 3. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Annex 4
-							if (c_PATH_ID == 2 && c_CAM_ID == 7 && vars.splits[67] != true) {
-								vars.splits[67] = true;
-								vars.LOG_LastSplit = "Annex 4. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Annex 5
-							if (c_PATH_ID == 2 && c_CAM_ID == 9 && vars.splits[68] != true) {
-								vars.splits[68] = true;
-								vars.LOG_LastSplit = "Annex 5. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Annex 6
-							if (o_PATH_ID == 2 && c_PATH_ID == 3 && vars.splits[69] != true) {
-								vars.splits[69] = true;
-								vars.LOG_LastSplit = "Annex 6. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-						// Annex 7
-							if (o_PATH_ID == 3 && c_PATH_ID == 4 && vars.splits[70] != true) {
-								vars.splits[70] = true;
-								vars.LOG_LastSplit = "Annex 7. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-						}
-						
-						if (c_LEVEL_ID == 14){
-						// Annex 8
-							if (c_PATH_ID == 14 && vars.splits[71] != true) {
-								vars.splits[71] = true;
-								vars.LOG_LastSplit = "Annex 8. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								return true;
-							}
-							
-							if (c_LEVEL_ID == 14 && c_PATH_ID == 9 && c_CAM_ID == 15) { // Screen with the glukkon intercom phone
-								vars.PrePhlegSplit = true;
-							}
-							
-						// Phleg
-							if (vars.PrePhlegSplit && c_PATH_ID == 9 && o_CAM_ID == 9 && c_CAM_ID == 8 && vars.splits[72] != true) {
-								vars.splits[72] = true;
-								vars.LOG_LastSplit = "Phleg. " + vars.LOG_CurrentRTA;
-								vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-								vars.PrePhlegSplit = false;
-								return true;
-							}
-						}
-					}		
-					
-					if (o_LEVEL_ID == 14 && c_LEVEL_ID == 5 && vars.splits[6] != true) { // Bonewerkz Split
-						vars.splits[6] = true;
-						vars.splits[8] = false; // If we are not going directly from FeeCo to Soulstorm, we can split on FeeCo 2.
-						if (settings["feeco2Split"] && vars.SplitFeeco2 == false){ // We enabled FeeCo 2 (between Barracks - Bonewerkz and the next one).
-							vars.splits[4] = false; // So we split again when entering on Barracks.
-							vars.splitsFeeCoAgain = vars.splits[4];
-							vars.SplitFeeco2 = true;
-						}
-						vars.LOG_LastSplit = "Bonewerkz. " + vars.LOG_CurrentRTA;
-						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ".";
-						return true;
-					}
-				}
-			//////////////////////////////
-
-			// Executive Office (LEVEL_ID 12)
-				if (settings["officeSplit"] || vars.ILid == 4) {
-					if ((settings["officeExtended"] || vars.ILid == 4) && c_LEVEL_ID == 12){ // 73, 74
-						
-					// Entry Executive Office
-						if ((o_CAM_ID == 4 && c_CAM_ID == 5) || (o_CAM_ID == 1 && c_CAM_ID == 2 && c_PATH_ID == 14) && vars.splits[73] != true) {
-							vars.splits[73] = true;
-							vars.LOG_LastSplit = "Entry Executive Office. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Aslik
-						if (c_CAM_ID == 2 && c_PATH_ID == 14 && vars.splits[74] != true) {
-							vars.splits[74] = true;
-							vars.LOG_LastSplit = "Aslik. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-					}
-					
-					if (o_LEVEL_ID == 12 && c_LEVEL_ID == 5 && vars.splits[7] != true) {
-						vars.splits[7] = true;
-						vars.LOG_LastSplit = "Executive Office. " + vars.LOG_CurrentRTA;
-						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-						return true;
-					}
-				}
-			//////////////////////////////	
-					
-			// FeeCo 3 (LEVEL_ID 5)
-				if ((settings["feeco3Split"] || vars.ILid == 4) && o_LEVEL_ID == 5 && c_LEVEL_ID == 9 && vars.splits[8] != true) {	
-					vars.splits[8] = true;
-						vars.LOG_LastSplit = "FeeCo to Terminal 5. " + vars.LOG_CurrentRTA;
-						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-					return true;
-				}
-					
-			// Hub I (LEVEL_ID 9)
-				if ((settings["hub1Split"] || vars.ILid == 7) && c_LEVEL_ID == 9){
-					if (settings["hub1Extended"] || vars.ILid == 7){ // 75 - 80
-					// SoulStorm Brewery Entry
-						if (o_PATH_ID == 16 && c_PATH_ID == 23 && vars.splits[75] != true) {
-							vars.splits[75] = true;
-							vars.LOG_LastSplit = "Zulag 0 (Soulstorm Brewery Entry). " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Zulag 1
-						if (o_PATH_ID == 1 && c_PATH_ID == 23 && vars.splits[76] != true) {
-							vars.splits[76] = true;
-							vars.LOG_LastSplit = "Zulag 1. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Zulag 2
-						if (o_PATH_ID == 2 && c_PATH_ID == 23 && vars.splits[77] != true) {
-							vars.splits[77] = true;
-							vars.LOG_LastSplit = "Zulag 2. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Zulag 3
-						if (o_PATH_ID == 12 && c_PATH_ID == 23 && vars.splits[78] != true) {
-							vars.splits[78] = true;
-							vars.LOG_LastSplit = "Zulag 3. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Zulag 4
-						if (o_PATH_ID == 19 && c_PATH_ID == 23 && vars.splits[79] != true) {
-							vars.splits[79] = true;
-							vars.LOG_LastSplit = "Zulag 4. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Zulag 5
-						if (o_PATH_ID == 14 && c_PATH_ID == 23 && vars.splits[80] != true) {
-							vars.splits[80] = true;
-							vars.LOG_LastSplit = "Zulag 5. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-					}	
-					
-				// Hub 1
-					if (o_PATH_ID == 23 && c_PATH_ID == 24 && vars.splits[9] != true) { 
-						vars.splits[9] = true;
-						vars.LOG_LastSplit = "Hub 1. " + vars.LOG_CurrentRTA;
-						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-						return true;
-					}
-				}
-			//////////////////////////////	
-
-			// Hub II
-				if ((settings["hub2Split"] || vars.ILid == 8) && c_LEVEL_ID == 9){
-					if (settings["hub2Extended"] || vars.ILid == 8){ // 81 - 85			
-					// Zulag 6
-						if (o_PATH_ID == 5 && o_CAM_ID == 4 && c_PATH_ID == 24 && vars.splits[81] != true) {
-							vars.splits[81] = true;
-							vars.LOG_LastSplit = "Zulag 6. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Zulag 7
-						if (o_PATH_ID == 6 && o_CAM_ID == 10 && c_PATH_ID == 24 && vars.splits[82] != true) {
-							vars.splits[82] = true;
-							vars.LOG_LastSplit = "Zulag 7. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Zulag 8
-						if (o_PATH_ID == 3 && c_PATH_ID == 24 && vars.splits[83] != true) {
-							vars.splits[83] = true;
-							vars.LOG_LastSplit = "Zulag 8. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Zulag 9
-						if (o_PATH_ID == 17 && c_PATH_ID == 24 && vars.splits[84] != true) {
-							vars.splits[84] = true;
-							vars.LOG_LastSplit = "Zulag 9. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Zulag 10
-						if (o_PATH_ID == 10 && c_PATH_ID == 24 && vars.splits[85] != true) {
-							vars.splits[85] = true;
-							vars.LOG_LastSplit = "Zulag 10. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-					}
-					
-				// Hub 2
-					if (o_PATH_ID == 24 && c_PATH_ID == 25 && vars.splits[10] != true) {
-						vars.splits[10] = true;
-						vars.LOG_LastSplit = "Hub 2. " + vars.LOG_CurrentRTA;
-						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-						return true;
-					}
-				}
-			//////////////////////////////
-				
-			// Hub III	
-				if (settings["hub3Split"] || vars.ILid == 9){
-					if ((settings["hub3Extended"] || vars.ILid == 9) && c_LEVEL_ID == 9){ // 86 - 89
-					// Zulag 11
-						if (o_PATH_ID == 9 && c_PATH_ID == 25 && vars.splits[86] != true) {
-							vars.splits[86] = true;
-							vars.LOG_LastSplit = "Zulag 11. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-					// Zulag 12
-						if (o_PATH_ID == 11 && c_PATH_ID == 25 && vars.splits[87] != true) {
-							vars.splits[87] = true;
-							vars.LOG_LastSplit = "Zulag 12. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-					// Zulag 13
-						if ((o_PATH_ID == 20 || o_PATH_ID == 15) && c_PATH_ID == 25 && vars.splits[88] != true) {
-							vars.splits[88] = true;
-							vars.LOG_LastSplit = "Zulag 13. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-						
-						
-					// Zulag 14
-						if (o_PATH_ID == 4 && o_CAM_ID == 13 && c_PATH_ID == 25 && vars.splits[89] != true) {
-							vars.splits[89] = true;
-							vars.LOG_LastSplit = "Zulag 14. " + vars.LOG_CurrentRTA;
-							vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-							return true;
-						}
-					}
-					
-				// Hub 3
-					if (c_LEVEL_ID == 10 && c_PATH_ID == 1 && vars.splits[11] != true) {
-						vars.splits[11] = true;
-						vars.LOG_LastSplit = "Hub 3. " + vars.LOG_CurrentRTA;
-						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-						return true;
-					}
-				}
-					
-			//////////////////////////////
-
-			// Soulstorm Brewery		
-				if ((settings["boilerSplit"] || vars.ILid == 10) && c_LEVEL_ID == 10 && (c_FMV_ID == 17 || c_FMV_ID == 18 || c_CAM_ID == 15) && vars.splits[12] != true) {		
-					vars.splits[12] = true;	
-					vars.LOG_LastSplit = "Zulag 15. Game is over! FINAL TIME-> " + vars.LOG_CurrentRTA;
-					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
-					return true;	
-				}
-		
+			}
 		}
+	//////////////////////////////
+
+	// Mudomo (LEVEL_ID 3, Vaults is LEVEL_ID 11)
+		if (settings["mudomoSplit"] || vars.ILid == 2){
+			if (c_LEVEL_ID == 3 && (settings["mudomoExtended"] || vars.ILid == 2)){ // 30 - 39
+			
+			// Mudomo Entry 1
+				if (c_FMV_ID == 29 && vars.splits[30] != true) {
+						vars.splits[30] = true;
+						vars.LOG_LastSplit = "Mudomo Entry 1. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Mudomo Entry 2
+				if (c_FMV_ID == 33 && vars.splits[31] != true) {
+						vars.splits[31] = true;
+						vars.LOG_LastSplit = "Mudomo Entry 2. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Mudomo Entry 3
+				if (c_PATH_ID == 8 && vars.splits[32] != true) {
+						vars.splits[32] = true;
+						vars.LOG_LastSplit = "Mudomo Entry 3. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Mudomo Trial 1
+				if (c_FMV_ID == 13 && vars.splits[33] != true) {
+						vars.splits[33] = true;
+						vars.LOG_LastSplit = "Mudomo Trial 1. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Mudomo Trial 2
+				if (c_FMV_ID == 17 && vars.splits[34] != true) {
+						vars.splits[34] = true;
+						vars.LOG_LastSplit = "Mudomo Trial 2. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Mudomo Trial 3
+				if (c_FMV_ID == 15 && vars.splits[35] != true) {
+						vars.splits[35] = true;
+						vars.LOG_LastSplit = "Mudomo Trial 3. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Mudomo Trial 4
+				if (c_FMV_ID == 9 && vars.splits[36] != true) {
+						vars.splits[36] = true;
+						vars.LOG_LastSplit = "Mudomo Trial 4. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Mudomo Trial 5
+				if (c_FMV_ID == 6 && vars.splits[37] != true) {
+						vars.splits[37] = true;
+						vars.LOG_LastSplit = "Mudomo Trial 5. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Mudomo Trial 6
+				if (c_FMV_ID == 31 && vars.splits[38] != true) {
+						vars.splits[38] = true;
+						vars.LOG_LastSplit = "Mudomo Trial 6. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			}
+			
+		// Mudomo Vaults
+			if ((settings["mudomoExtended"] || vars.ILid == 2) && o_LEVEL_ID == 11 && c_LEVEL_ID == 2 && vars.splits[39] != true) {
+				vars.splits[39] = true;
+				vars.LOG_LastSplit = "Mudomo Vaults. " + vars.LOG_CurrentRTA;
+				vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+				return true;
+			}
+			
+		// PRE-Mudomo split
+			if (c_LEVEL_ID == 2 && c_PATH_ID == 5 && c_CAM_ID == 1 && c_FMV_ID != 8){ 
+				vars.preSplitMudomo = true;
+			}
+		
+		// Mudomo split
+			if ((vars.countToMud >= 1000 || vars.ILid == 2) && ((c_LEVEL_ID == 4 && c_PATH_ID == 6 && c_CAM_ID == 23 && c_FMV_ID == 34 && vars.preSplitMudomo) || (o_PATH_ID == 3 && c_PATH_ID == 1 && c_LEVEL_ID == 5)) && vars.splits[2] != true) { 
+				vars.splits[2] = true;
+				vars.LOG_LastSplit = "Mudomo. " + vars.LOG_CurrentRTA;
+				vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+				return true;
+			}
+		}
+	//////////////////////////////
+
+	// Mudanchee (LEVEL_ID 4)
+		if (settings["mudancheeSplit"] || vars.ILid == 3){
+			if (settings["mudancheeExtended"] || vars.ILid == 3){ // 40 - 50
+				if (c_LEVEL_ID == 4){
+				// Mudanchee Entry 1
+					if (c_FMV_ID == 25 && vars.splits[40] != true) {
+						vars.splits[40] = true;
+						vars.LOG_LastSplit = "Mudanchee Entry 1. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Mudanchee Entry 2
+					if (c_FMV_ID == 30 && vars.splits[41] != true) {
+						vars.splits[41] = true;
+						vars.LOG_LastSplit = "Mudanchee Entry 2. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Mudanchee Entry 3
+					if (c_FMV_ID == 28 && vars.splits[42] != true) {
+						vars.splits[42] = true;
+						vars.LOG_LastSplit = "Mudanchee Entry 3. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Mudanchee Entry 4
+					if (c_PATH_ID == 7 && o_CAM_ID == 2 && c_CAM_ID == 4 && vars.splits[43] != true) {
+						vars.splits[43] = true;
+						vars.LOG_LastSplit = "Mudanchee Entry 4. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Mudanchee Trial 1
+					if (c_FMV_ID == 2 && vars.splits[44] != true) {
+						vars.splits[44] = true;
+						vars.LOG_LastSplit = "Mudanchee Trial 1. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Mudanchee Trial 2
+					if (c_FMV_ID == 6 && vars.splits[45] != true) {
+						vars.splits[45] = true;
+						vars.LOG_LastSplit = "Mudanchee Trial 2. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Mudanchee Trial 3
+					if (c_FMV_ID == 23 && vars.splits[46] != true) {
+						vars.splits[46] = true;
+						vars.LOG_LastSplit = "Mudanchee Trial 3. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Mudanchee Trial 4
+					if (c_FMV_ID == 14 && vars.splits[47] != true) {
+						vars.splits[47] = true;
+						vars.LOG_LastSplit = "Mudanchee Trial 4. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Mudanchee Trial 5
+					if (c_FMV_ID == 3 && vars.splits[48] != true) {
+						vars.splits[48] = true;
+						vars.LOG_LastSplit = "Mudanchee Trial 5. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Mudanchee Trial 6
+					if (c_FMV_ID == 11 && vars.splits[49] != true) {
+						vars.splits[49] = true;
+						vars.LOG_LastSplit = "Mudanchee Trial 6. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+				}
+				
+			// Mudanchee Vaults
+				if (o_LEVEL_ID == 7 && c_LEVEL_ID == 2 && vars.splits[50] != true) { 
+					vars.splits[50] = true;
+					vars.LOG_LastSplit = "Mudanchee Vaults. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+			}
+
+			if (c_LEVEL_ID == 2 && c_PATH_ID == 5 && c_CAM_ID == 9 && c_FMV_ID != 8){ // Pre-Mudanchee split
+				vars.preSplitMudanchee = true;
+			}
+			
+			if ((vars.countToMud >= 1000 || vars.ILid == 3) && ((c_LEVEL_ID == 3 && c_PATH_ID == 1 && c_CAM_ID == 1 && c_FMV_ID == 25 && vars.preSplitMudanchee) || (o_PATH_ID == 3 && c_PATH_ID == 1 && c_LEVEL_ID == 5)) && vars.splits[3] != true) { // Mudanchee Split: we are in Mudomo or Wheel to FeeCo. 
+				vars.splits[3] = true;
+				vars.LOG_LastSplit = "Mudanchee. " + vars.LOG_CurrentRTA;
+				vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+				return true;
+			}
+		}
+	//////////////////////////////
+		
+	// Necrum (LEVEL_ID 2)
+		if (settings["necrumSplit"] || vars.ILid == 1) {
+			if (c_LEVEL_ID == 2){
+				if (settings["necrumExtended"] || vars.ILid == 1) { // 22 - 29
+				// Necrum Entry SPLIT
+					if (c_FMV_ID == 10 && vars.splits[22] != true) {
+						vars.splits[22] = true;
+						vars.LOG_LastSplit = "Necrum Entry. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Hands SPLIT
+					if (c_FMV_ID == 9 && vars.splits[23] != true) {
+						vars.splits[23] = true;
+						vars.LOG_LastSplit = "Handstones. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Fleeches Entry SPLIT
+					if (c_FMV_ID == 6 && vars.splits[24] != true) {
+						vars.splits[24] = true;
+						vars.LOG_LastSplit = "Fleeches Entry. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Fleeches 1 SPLIT
+					if (c_FMV_ID == 18 && vars.splits[25] != true) {
+						vars.splits[25] = true;
+						vars.LOG_LastSplit = "Fleeches 1. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Fleeches 2 SPLIT
+					if (c_FMV_ID == 19 && vars.splits[26] != true) {
+						vars.splits[26] = true;
+						vars.LOG_LastSplit = "Fleeches 2. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Fleeches 3 SPLIT
+					if (c_FMV_ID == 20 && vars.splits[27] != true) {
+						vars.splits[27] = true;
+						vars.LOG_LastSplit = "Fleeches 3. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Fleeches 4 SPLIT
+					if (c_FMV_ID == 21 && vars.splits[28] != true) {
+						vars.splits[28] = true;
+						vars.LOG_LastSplit = "Fleeches 4. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Fleeches 5 SPLIT
+					if (c_FMV_ID == 15 && vars.splits[29] != true) {
+						vars.splits[29] = true;
+						vars.LOG_LastSplit = "Fleeches 5. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+				}
+				
+			// Necrum pre-SPLIT
+				if (c_PATH_ID == 5 && (c_CAM_ID == 9 || c_CAM_ID == 1) && vars.FMVNecrum == 8){ // Prepare for last split
+					vars.preSplitNecrum = true;
+					vars.FMVNecrum = 0;
+				}			
+			} 
+			
+			if (c_LEVEL_ID == 2 && c_FMV_ID == 8){
+				vars.FMVNecrum = c_FMV_ID;
+			}
+			
+			// Necrum SPLITS
+			if (vars.ILid == -1 && vars.preSplitNecrum && (c_FMV_ID == 25 || c_FMV_ID == 34) && (c_LEVEL_ID >= 2 && c_LEVEL_ID <= 4) && vars.splits[1] != true) { // Cinematics: 25 is mudomo (24 end). 34 is Mudanchee (25 end). 4 is FeeCo.
+				vars.splits[1] = true;
+				vars.preSplitNecrum = false;
+				vars.countToMud = 1;
+				vars.LOG_LastSplit = "Necrum to Mudomo / Mudanchee. " + vars.LOG_CurrentRTA;
+				vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+				return true;
+			}
+			
+			if (vars.ILid == 1 && o_LEVEL_ID == 2 && c_LEVEL_ID == 3 && c_FMV_ID == 25){ // Necrum to Mudomo, we prepare to the next save file
+				vars.ILWaitTimer = true;						
+				vars.splits[55] = true; // Recycled for Necrum to Mudanchee split
+				return true;
+			}
+			
+			if (vars.ILid == 1 && o_CAM_ID == 5 && c_CAM_ID == 6 && vars.splits[55] == true){ // Save file 2.
+				vars.ILWaitTimer = false;						
+				vars.splits[55] = false;
+				return true;
+			}
+			
+			if (vars.ILid == 1 && o_LEVEL_ID == 2 && c_LEVEL_ID == 4 && c_FMV_ID == 34){ // Necrum to Mudanchee, we prepare to the next save file
+				vars.ILWaitTimer = true;						
+				vars.splits[56] = true; // Recycled for Necrum to FeeCo split
+				return true;
+			}					
+			
+			if (vars.ILid == 1 && o_LEVEL_ID == 7 && c_LEVEL_ID == 2 && vars.splits[56] == true){ // Save file 3.
+				vars.ILWaitTimer = false;						
+				vars.splits[56] = false; // Recycled for Necrum to Mudanchee split
+				return true;
+			}
+			
+			if (c_LEVEL_ID == 5 && o_LEVEL_ID == 2 && ((vars.splits[2] != true && vars.splits[3] != true) || (vars.ILid == 1))){ // From Necrum to FeeCo directly (Any%)
+				vars.splits[1] = true;
+				vars.splits[2] = true; // We will not use it anymore.
+				vars.splits[3] = true; // We will not use it anymore.
+				vars.preSplitNecrum = false;
+				vars.LOG_LastSplit = "Necrum to FeeCo. " + vars.LOG_CurrentRTA;
+				vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+				return true;
+			}
+		}
+	//////////////////////////////
+
+	// FeeCo & FeeCo 2 (LEVEL_ID 5)
+		if (settings["feecoSplit"] || vars.ILid == 4) { 					
+			if ((settings["feecoExtended"] || vars.ILid == 4) && c_LEVEL_ID == 2 && o_PATH_ID == 3 && o_CAM_ID == 2 && c_PATH_ID == 3 && c_CAM_ID == 9 && vars.splits[1] == true && vars.splits[2] == true && vars.splits[3] == true) { // SPECIAL: FeeCo entry through Necrum using Farewell FeeCo skip
+				vars.splits[51] = true;
+				vars.LOG_LastSplit = "Special split: Necrum to Terminal 1 (Any% | Farewell FeeCo skip). " + vars.LOG_CurrentRTA;
+				vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+				return true;
+			}
+			
+			if ((settings["feecoExtended"] || vars.ILid == 4) && c_LEVEL_ID == 5) { // 51 - 55		
+			// FeeCo Entry
+				if (c_PATH_ID == 1 && c_CAM_ID == 3 && vars.splits[51] != true) {
+					vars.splits[51] = true;
+					vars.LOG_LastSplit = "FeeCo Entry. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Terminal 1
+				if (c_PATH_ID == 7 && c_CAM_ID == 1 && vars.splits[52] != true) {
+					vars.splits[52] = true;
+					vars.LOG_LastSplit = "Terminal 1. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Terminal 2
+				if (o_PATH_ID == 7 && c_PATH_ID == 2 && c_CAM_ID == 8 && (vars.splits[53] != true || vars.splits[0] == true || vars.splits[1] == true) && vars.Terminal2Split == false) { // 0 is for 2nd save. 1 is for 3rd save file.
+					vars.Terminal2Split = true;
+					vars.splits[53] = true;
+					if (vars.splits[1] == true){ // Loading the second save file						
+						vars.LOG_LastSplit = "Terminal 2 (go to Executive Office!) " + vars.LOG_CurrentRTA;	
+					} else if (vars.splits[0] == true){ // Loading the third save file					
+						vars.LOG_LastSplit = "Terminal 2 (go to Bonewerkz!) " + vars.LOG_CurrentRTA;			
+					} else { // First time we come here
+						vars.LOG_LastSplit = "Terminal 2 (go to Barracks!) " + vars.LOG_CurrentRTA;								
+					}
+					if (vars.splits[1] == true){								
+						vars.splits[0] = false;
+						vars.splits[1] = false;
+					}
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					vars.ILWaitTimer = false;
+					return true;
+				}
+				
+			// Terminal principal to Slig Barracks
+				// if (o_PATH_ID == 9 && c_PATH_ID == 5 && vars.splits[54] != true) { // If I enter on Terminal 3
+				if (o_PATH_ID == 9 && c_PATH_ID == 3 && vars.splits[54] != true) { // If I enter on Terminal 3
+					vars.splits[54] = true;
+					vars.Terminal2Split = false;
+					vars.LOG_LastSplit = "Main Terminal to Terminal 3. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Terminal principal to Bonewerkz
+				if (o_PATH_ID == 9 && c_PATH_ID == 4 && vars.splits[54] != true) { // If I enter on Terminal 4
+					vars.splits[54] = true;
+					vars.Terminal2Split = false;
+					vars.LOG_LastSplit = "Main Terminal to Terminal 4. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Terminal principal to Soulstorm Brewery
+				if (o_PATH_ID == 2 && c_PATH_ID == 5 && vars.splits[54] != true) { // If I enter on Terminal 5
+					vars.splits[54] = true;
+					vars.Terminal2Split = false;
+					vars.LOG_LastSplit = "Main Terminal to Terminal 5. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+					
+			// Terminal 3
+				if (c_PATH_ID == 5 && o_CAM_ID == 3 && c_CAM_ID == 14 && vars.splits[55] != true) {
+					vars.splits[55] = true;
+					vars.Terminal2Split = false;
+					vars.LOG_LastSplit = "Terminal 3. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+					
+			// Terminal 4
+				if (vars.ILid == -1 && c_PATH_ID == 4 && o_CAM_ID == 13 && c_CAM_ID == 14 && vars.splits[55] != true) {
+					vars.splits[55] = true;
+					vars.Terminal2Split = false;
+					vars.LOG_LastSplit = "Terminal 4. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+					
+			// Terminal 5
+				if (c_PATH_ID == 5 && o_CAM_ID == 7 && c_CAM_ID == 14 && vars.splits[55] != true) {
+					vars.splits[55] = true;
+					vars.Terminal2Split = false;
+					vars.LOG_LastSplit = "Terminal 5. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+			}		
+		}
+		// Enter on any of the train doors
+		if (vars.ILid == 4 && o_LEVEL_ID == 5 && (c_LEVEL_ID == 6 || c_LEVEL_ID == 8 || c_LEVEL_ID == 9) && (vars.splits[0] != true || vars.splits[1] != true)){ 				
+			vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+			vars.ILWaitTimer = true;	
+			vars.Terminal2Split = false;					
+			if (vars.splits[0] == false){								
+				vars.splits[0] = true;						
+				vars.LOG_LastSplit = "FeeCo 1. (LOAD SAVE FILE 2)" + vars.LOG_CurrentRTA;
+			} else {						
+				vars.splits[1] = true;		
+				vars.LOG_LastSplit = "FeeCo 2. (LOAD SAVE FILE 3)" + vars.LOG_CurrentRTA;	
+			}
+			return true;
+		}
+			
+		if (vars.ILid == -1 && (settings["feecoSplit"] || vars.SplitFeeco2 || vars.ILid == 4) && o_LEVEL_ID == 5 && (c_LEVEL_ID == 6 || c_LEVEL_ID == 8 || c_LEVEL_ID == 9) && vars.splits[4] != true) { // FeeCo Split. 6 is Bonewerkz.  5 is Barracks. 15 is Brewery
+			vars.splits[4] = true;
+			vars.splitsFeeCoAgain = vars.splits[4];
+			vars.splits[8] = true; // We avoid double split if we go from FeeCo to Soulstorm directly.
+			if (vars.splits[5]) { // Slig Barracks ya fue completado.
+				vars.LOG_LastSplit = "FeeCo 2 to Bonewerkz. " + vars.LOG_CurrentRTA;
+			} else if (vars.splits[6]){ // Bonewerkz ya fue completado.
+				vars.LOG_LastSplit = "FeeCo 2 to Slig Barracks. " + vars.LOG_CurrentRTA;		
+			} else { // Nada fue completado.
+				vars.LOG_LastSplit = "FeeCo 1. " + vars.LOG_CurrentRTA;
+			}
+			vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+			return true;
+		}
+	//////////////////////////////
+			
+	// Slig Barracks (LEVEL_ID 6)
+		if (settings["barracksSplit"] || vars.ILid == 6) {
+			if ((settings["barracksExtended"] || vars.ILid == 6) && c_LEVEL_ID == 6) { // 56 - 62			
+			// Block 0
+				if (o_PATH_ID == 13 && c_PATH_ID == 2 && vars.splits[56] != true) {
+					vars.splits[56] = true;
+					vars.LOG_LastSplit = "Block 0. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Block 1
+				if (o_PATH_ID == 10 && c_PATH_ID == 2 && vars.splits[57] != true) {
+					vars.splits[57] = true;
+					vars.LOG_LastSplit = "Block 1. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Block 2
+				if (o_PATH_ID == 5 && c_PATH_ID == 2 && vars.splits[58] != true) {
+					vars.splits[58] = true;
+					vars.LOG_LastSplit = "Block 2. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Block 3
+				if (o_PATH_ID == 7 && c_PATH_ID == 2 && vars.splits[59] != true) {
+					vars.splits[59] = true;
+					vars.LOG_LastSplit = "Block 3. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Block 4
+				if (o_PATH_ID == 14 && c_PATH_ID == 2 && vars.splits[60] != true) {
+					vars.splits[60] = true;
+					vars.LOG_LastSplit = "Block 4. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}	
+			
+			}
+		// Dripik (fixed 08 June 2020)
+			if ((settings["barracksExtended"] || vars.ILid == 6) && c_LEVEL_ID == 13 && o_PATH_ID == 11 && c_PATH_ID == 16 && vars.splits[61] != true) {
+				vars.splits[61] = true;
+				vars.LOG_LastSplit = "Dripik. " + vars.LOG_CurrentRTA;
+				vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+				return true;
+			}	
+			
+			
+			
+		// Slig Barracks Split
+			if (o_LEVEL_ID == 13 && c_LEVEL_ID == 5 && vars.splits[5] != true) { 
+				vars.splits[5] = true;
+				vars.splits[8] = false; // If we are not going directly from FeeCo to Soulstorm, we can split on FeeCo 2.
+				if (settings["feeco2Split"] && vars.SplitFeeco2 == false){
+					vars.splits[4] = false; // So we split again when entering on Bonewerkz.
+					vars.splitsFeeCoAgain = vars.splits[4];
+					vars.SplitFeeco2 = true;
+				}
+				vars.LOG_LastSplit = "Slig Barracks. " + vars.LOG_CurrentRTA;
+				vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+				return true;
+			}
+		}
+	//////////////////////////////
+			
+	// Bonewerkz (LEVEL_ID 8 and 14)
+		if (settings["bonewerkzSplit"] || vars.ILid == 5) {
+			if (settings["bonewerkzExtended"] || vars.ILid == 5) { // 63 - 72
+				if (c_LEVEL_ID == 8){			
+				// Bonewerkz Entry
+					if (o_PATH_ID == 1 && c_PATH_ID == 7 && vars.splits[63] != true) {
+						vars.splits[63] = true;
+						vars.LOG_LastSplit = "Bonewerkz Entry. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Annex 1
+					if (o_PATH_ID == 7 && c_PATH_ID == 1 && vars.splits[64] != true) {
+						vars.splits[64] = true;
+						vars.LOG_LastSplit = "Annex 1. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Annex 2
+					if (o_PATH_ID == 1 && c_PATH_ID == 2 && vars.splits[65] != true) {
+						vars.splits[65] = true;
+						vars.LOG_LastSplit = "Annex 2. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Annex 3
+					if (c_PATH_ID == 2 && c_CAM_ID == 4 && vars.splits[66] != true) {
+						vars.splits[66] = true;
+						vars.LOG_LastSplit = "Annex 3. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Annex 4
+					if (c_PATH_ID == 2 && c_CAM_ID == 7 && vars.splits[67] != true) {
+						vars.splits[67] = true;
+						vars.LOG_LastSplit = "Annex 4. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Annex 5
+					if (c_PATH_ID == 2 && c_CAM_ID == 9 && vars.splits[68] != true) {
+						vars.splits[68] = true;
+						vars.LOG_LastSplit = "Annex 5. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Annex 6
+					if (o_PATH_ID == 2 && c_PATH_ID == 3 && vars.splits[69] != true) {
+						vars.splits[69] = true;
+						vars.LOG_LastSplit = "Annex 6. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+				// Annex 7
+					if (o_PATH_ID == 3 && c_PATH_ID == 4 && vars.splits[70] != true) {
+						vars.splits[70] = true;
+						vars.LOG_LastSplit = "Annex 7. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+				}
+				
+				if (c_LEVEL_ID == 14){
+				// Annex 8
+					if (c_PATH_ID == 14 && vars.splits[71] != true) {
+						vars.splits[71] = true;
+						vars.LOG_LastSplit = "Annex 8. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						return true;
+					}
+					
+					if (c_LEVEL_ID == 14 && c_PATH_ID == 9 && c_CAM_ID == 15) { // Screen with the glukkon intercom phone
+						vars.PrePhlegSplit = true;
+					}
+					
+				// Phleg
+					if (vars.PrePhlegSplit && c_PATH_ID == 9 && o_CAM_ID == 9 && c_CAM_ID == 8 && vars.splits[72] != true) {
+						vars.splits[72] = true;
+						vars.LOG_LastSplit = "Phleg. " + vars.LOG_CurrentRTA;
+						vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+						vars.PrePhlegSplit = false;
+						return true;
+					}
+				}
+			}		
+			
+			if (o_LEVEL_ID == 14 && c_LEVEL_ID == 5 && vars.splits[6] != true) { // Bonewerkz Split
+				vars.splits[6] = true;
+				vars.splits[8] = false; // If we are not going directly from FeeCo to Soulstorm, we can split on FeeCo 2.
+				if (settings["feeco2Split"] && vars.SplitFeeco2 == false){ // We enabled FeeCo 2 (between Barracks - Bonewerkz and the next one).
+					vars.splits[4] = false; // So we split again when entering on Barracks.
+					vars.splitsFeeCoAgain = vars.splits[4];
+					vars.SplitFeeco2 = true;
+				}
+				vars.LOG_LastSplit = "Bonewerkz. " + vars.LOG_CurrentRTA;
+				vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ".";
+				return true;
+			}
+		}
+	//////////////////////////////
+
+	// Executive Office (LEVEL_ID 12)
+		if (settings["officeSplit"] || vars.ILid == 4) {
+			if ((settings["officeExtended"] || vars.ILid == 4) && c_LEVEL_ID == 12){ // 73, 74
+				
+			// Entry Executive Office
+				if ((o_CAM_ID == 4 && c_CAM_ID == 5) || (o_CAM_ID == 1 && c_CAM_ID == 2 && c_PATH_ID == 14) && vars.splits[73] != true) {
+					vars.splits[73] = true;
+					vars.LOG_LastSplit = "Entry Executive Office. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Aslik
+				if (c_CAM_ID == 2 && c_PATH_ID == 14 && vars.splits[74] != true) {
+					vars.splits[74] = true;
+					vars.LOG_LastSplit = "Aslik. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+			}
+			
+			if (o_LEVEL_ID == 12 && c_LEVEL_ID == 5 && vars.splits[7] != true) {
+				vars.splits[7] = true;
+				vars.LOG_LastSplit = "Executive Office. " + vars.LOG_CurrentRTA;
+				vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+				return true;
+			}
+		}
+	//////////////////////////////	
+			
+	// FeeCo 3 (LEVEL_ID 5)
+		if ((settings["feeco3Split"] || vars.ILid == 4) && o_LEVEL_ID == 5 && c_LEVEL_ID == 9 && vars.splits[8] != true) {	
+			vars.splits[8] = true;
+				vars.LOG_LastSplit = "FeeCo to Terminal 5. " + vars.LOG_CurrentRTA;
+				vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+			return true;
+		}
+			
+	// Hub I (LEVEL_ID 9)
+		if ((settings["hub1Split"] || vars.ILid == 7) && c_LEVEL_ID == 9){
+			if (settings["hub1Extended"] || vars.ILid == 7){ // 75 - 80
+			// SoulStorm Brewery Entry
+				if (o_PATH_ID == 16 && c_PATH_ID == 23 && vars.splits[75] != true) {
+					vars.splits[75] = true;
+					vars.LOG_LastSplit = "Zulag 0 (Soulstorm Brewery Entry). " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Zulag 1
+				if (o_PATH_ID == 1 && c_PATH_ID == 23 && vars.splits[76] != true) {
+					vars.splits[76] = true;
+					vars.LOG_LastSplit = "Zulag 1. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Zulag 2
+				if (o_PATH_ID == 2 && c_PATH_ID == 23 && vars.splits[77] != true) {
+					vars.splits[77] = true;
+					vars.LOG_LastSplit = "Zulag 2. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Zulag 3
+				if (o_PATH_ID == 12 && c_PATH_ID == 23 && vars.splits[78] != true) {
+					vars.splits[78] = true;
+					vars.LOG_LastSplit = "Zulag 3. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Zulag 4
+				if (o_PATH_ID == 19 && c_PATH_ID == 23 && vars.splits[79] != true) {
+					vars.splits[79] = true;
+					vars.LOG_LastSplit = "Zulag 4. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Zulag 5
+				if (o_PATH_ID == 14 && c_PATH_ID == 23 && vars.splits[80] != true) {
+					vars.splits[80] = true;
+					vars.LOG_LastSplit = "Zulag 5. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+			}	
+			
+		// Hub 1
+			if (o_PATH_ID == 23 && c_PATH_ID == 24 && vars.splits[9] != true) { 
+				vars.splits[9] = true;
+				vars.LOG_LastSplit = "Hub 1. " + vars.LOG_CurrentRTA;
+				vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+				return true;
+			}
+		}
+	//////////////////////////////	
+
+	// Hub II
+		if ((settings["hub2Split"] || vars.ILid == 8) && c_LEVEL_ID == 9){
+			if (settings["hub2Extended"] || vars.ILid == 8){ // 81 - 85			
+			// Zulag 6
+				if (o_PATH_ID == 5 && o_CAM_ID == 4 && c_PATH_ID == 24 && vars.splits[81] != true) {
+					vars.splits[81] = true;
+					vars.LOG_LastSplit = "Zulag 6. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Zulag 7
+				if (o_PATH_ID == 6 && o_CAM_ID == 10 && c_PATH_ID == 24 && vars.splits[82] != true) {
+					vars.splits[82] = true;
+					vars.LOG_LastSplit = "Zulag 7. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Zulag 8
+				if (o_PATH_ID == 3 && c_PATH_ID == 24 && vars.splits[83] != true) {
+					vars.splits[83] = true;
+					vars.LOG_LastSplit = "Zulag 8. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Zulag 9
+				if (o_PATH_ID == 17 && c_PATH_ID == 24 && vars.splits[84] != true) {
+					vars.splits[84] = true;
+					vars.LOG_LastSplit = "Zulag 9. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Zulag 10
+				if (o_PATH_ID == 10 && c_PATH_ID == 24 && vars.splits[85] != true) {
+					vars.splits[85] = true;
+					vars.LOG_LastSplit = "Zulag 10. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+			}
+			
+		// Hub 2
+			if (o_PATH_ID == 24 && c_PATH_ID == 25 && vars.splits[10] != true) {
+				vars.splits[10] = true;
+				vars.LOG_LastSplit = "Hub 2. " + vars.LOG_CurrentRTA;
+				vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+				return true;
+			}
+		}
+	//////////////////////////////
+		
+	// Hub III	
+		if (settings["hub3Split"] || vars.ILid == 9){
+			if ((settings["hub3Extended"] || vars.ILid == 9) && c_LEVEL_ID == 9){ // 86 - 89
+			// Zulag 11
+				if (o_PATH_ID == 9 && c_PATH_ID == 25 && vars.splits[86] != true) {
+					vars.splits[86] = true;
+					vars.LOG_LastSplit = "Zulag 11. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+			// Zulag 12
+				if (o_PATH_ID == 11 && c_PATH_ID == 25 && vars.splits[87] != true) {
+					vars.splits[87] = true;
+					vars.LOG_LastSplit = "Zulag 12. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+			// Zulag 13
+				if ((o_PATH_ID == 20 || o_PATH_ID == 15) && c_PATH_ID == 25 && vars.splits[88] != true) {
+					vars.splits[88] = true;
+					vars.LOG_LastSplit = "Zulag 13. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+				
+				
+			// Zulag 14
+				if (o_PATH_ID == 4 && o_CAM_ID == 13 && c_PATH_ID == 25 && vars.splits[89] != true) {
+					vars.splits[89] = true;
+					vars.LOG_LastSplit = "Zulag 14. " + vars.LOG_CurrentRTA;
+					vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+					return true;
+				}
+			}
+			
+		// Hub 3
+			if (c_LEVEL_ID == 10 && c_PATH_ID == 1 && vars.splits[11] != true) {
+				vars.splits[11] = true;
+				vars.LOG_LastSplit = "Hub 3. " + vars.LOG_CurrentRTA;
+				vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+				return true;
+			}
+		}
+			
+	//////////////////////////////
+
+	// Soulstorm Brewery		
+		if ((settings["boilerSplit"] || vars.ILid == 10) && c_LEVEL_ID == 10 && (c_FMV_ID == 17 || c_FMV_ID == 18 || c_CAM_ID == 15) && vars.splits[12] != true) {		
+			vars.splits[12] = true;	
+			vars.LOG_LastSplit = "Zulag 15. Game is over! FINAL TIME-> " + vars.LOG_CurrentRTA;
+			vars.DEBUG_LocationLastSplit = "Level = " + c_LEVEL_ID + ". Path = " + c_PATH_ID + ". Cam = " + c_CAM_ID + ". FMV = " + c_FMV_ID + ". abeY = " + abeY + ".";
+			return true;	
+		}
+
 	}
 	
 //##########################################################


### PR DESCRIPTION
- Optimized the `start` method, might help a tiny bit with performance when the timer is not running.
- Moved the reset logic to its own `reset` method, making the code a bit easier to read.
- Improved the in-game time handling by moving most of the logic from `isLoading` to `gameTime`. That way, we force the internal LiveSplit IGT to be the exact same as the variable one. This should help getting accurate gold and deltas, and greatly improve performance as we're not doing TimeSpan comparison every tick anymore.
- Moved the variable reset logic from `split` to `start`. Thus, we only reset the variables once at the start of the run, and we're not doing String comparison every tick anymore. This should help with performance issues. This sadly causes a stupid git diff due to the change in indentation by removing the if/else statement, but it is what it is...